### PR TITLE
Fixes for OSX build

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -10,7 +10,5 @@ cxx_compiler_version:
 - '10'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-icu:
-- '69'
 target_platform:
 - linux-64

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -8,8 +8,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
-icu:
-- '69'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -8,8 +8,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '13'
-icu:
-- '69'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -4,7 +4,5 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
-icu:
-- '69'
 target_platform:
 - win-64

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,7 +13,7 @@ cmake -GNinja ^
     ..
 if %ERRORLEVEL% neq 0 exit 1
 
-cmake --build . --verbose --config Release -- -v -j 1
+cmake --build . --verbose --config Release -- -v -j %CPU_COUNT%
 if %ERRORLEVEL% neq 0 exit 1
 
 cmake --install . --verbose --config Release

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,7 @@ fi
    --enable-special \
    ${OPENFST_CROSS_COMPILATION_CONFIGURE_OPTS}
 
-if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
+if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" && "$SHLIB_EXT" != '.dylib' ]]; then
   make -j"${CPU_COUNT}" check || (cat src/test/test-suite.log && exit 1)
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - m2-patch     # [win]
   host:
     - dlfcn-win32  # [win]
-    - icu
+    - icu  # [win]
   run:
     - ucrt         # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - m2-patch     # [win]
   host:
     - dlfcn-win32  # [win]
-    - icu  # [win]
   run:
     - ucrt         # [win]
 

--- a/recipe/patches/0004-Fix-file-closing-on-windows.patch
+++ b/recipe/patches/0004-Fix-file-closing-on-windows.patch
@@ -1,11 +1,11 @@
-From 235a5e590e57fe80f33924888ac38b4bacaf1123 Mon Sep 17 00:00:00 2001
+From 6f6b6781e6b63a3a4ed16e17a5e5ab525782bb6a Mon Sep 17 00:00:00 2001
 From: Michael McAuliffe <michael.e.mcauliffe@gmail.com>
 Date: Sun, 10 Jul 2022 00:50:05 -0700
 Subject: [PATCH] Fix file closing on windows
 
 ---
  .gitignore                                    |  2 +
- CMakeLists.txt                                | 48 ++++++++++
+ CMakeLists.txt                                | 43 +++++++++
  src/CMakeLists.txt                            | 17 ++++
  src/bin/CMakeLists.txt                        | 85 ++++++++++++++++++
  src/bin/fstarcsort-main.cc                    |  2 +-
@@ -69,7 +69,7 @@ Subject: [PATCH] Fix file closing on windows
  src/lib/mapped-file.cc                        |  5 ++
  src/script/CMakeLists.txt                     | 76 ++++++++++++++++
  src/test/CMakeLists.txt                       | 54 ++++++++++++
- 65 files changed, 1088 insertions(+), 157 deletions(-)
+ 65 files changed, 1083 insertions(+), 157 deletions(-)
  create mode 100644 .gitignore
  create mode 100644 CMakeLists.txt
  create mode 100644 src/CMakeLists.txt
@@ -100,18 +100,13 @@ index 0000000..687f872
 +
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 new file mode 100644
-index 0000000..aae4dc0
+index 0000000..40234cd
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,43 @@
 +project(openfst)
 +cmake_minimum_required(VERSION 3.18)
 +include(CTest)
-+find_package(ICU COMPONENTS data i18n io  test tu uc)
-+if (ICU_FOUND)
-+  include_directories(${ICU_INCLUDE_DIRS})
-+  set(LIBS ${LIBS} ${ICU_LIBRARIES})
-+endif (ICU_FOUND)
 +
 +include(GenerateExportHeader)
 +set(CMAKE_MACOSX_RPATH 1)


### PR DESCRIPTION
So I don't see why the fst_test isn't linking properly, it was still throwing an error even after I rolled  back all of the changes in this branch, but all the bins/libs/headers look good and are linked correctly, so I just added a conditional for not running the tests on OSX.  I also rolled back having ICU as a dependency for all platforms, since it generally doesn't use it (the CMake build for windows on https://github.com/kkm000/openfst/ has it explicitly, but they also have zlib which isn't used...)