### PR TITLE
Add Linux patch for missing headers

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -40,23 +40,23 @@ if [[ "$SHLIB_EXT" == '.dylib' ]]; then
 else
   # Get an updated config.sub and config.guess
   cp $BUILD_PREFIX/share/gnuconfig/config.* .
+  if [[ "${CONDA_BUILD_CROSS_COMPILATION}" == "1" ]]; then
+    OPENFST_CROSS_COMPILATION_CONFIGURE_OPTS="--build=${BUILD} --host=${HOST}"
+  else
+    OPENFST_CROSS_COMPILATION_CONFIGURE_OPTS=""
+  fi
 
   ./configure \
      --prefix="${PREFIX}" \
      --enable-static=no \
      --enable-compress \
-     --enable-compact-fsts \
      --enable-fsts \
-     --enable-far \
      --enable-grm \
-     --enable-special \
-     --enable-linear-fsts \
-     --enable-lookahead-fsts \
-     --enable-mpdt \
-     --enable-ngram-fsts \
-     --enable-pdt
+     --enable-special ${OPENFST_CROSS_COMPILATION_CONFIGURE_OPTS}
 
-  make -j"${CPU_COUNT}" check || (cat src/test/test-suite.log && exit 1)
+  if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
+    make -j"${CPU_COUNT}" check || (cat src/test/test-suite.log && exit 1)
+  fi
 
   make -j"${CPU_COUNT}" install
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
     - patches/0001-Remove-float-equality-check-in-cross-compiling.patch  # [build_platform != target_platform]
     - patches/0002-add-missing-header.patch
     - patches/0003-add-no-undefined-to-some-LDFLAGS.patch                # [win]
-    - patches/0004-Cross-platform-CMake-build.patch                     # [not linux]
+    - patches/0004-Cross-platform-CMake-build.patch                      # [not linux]
+    - patches/0005-Update-installation-of-fsts-headers.patch             # [linux]
 
 build:
   number: 2

--- a/recipe/patches/0005-Update-installation-of-fsts-headers.patch
+++ b/recipe/patches/0005-Update-installation-of-fsts-headers.patch
@@ -1,0 +1,38 @@
+From dc4fbab1500ec01cddcef5ec01b29f942fd89ff4 Mon Sep 17 00:00:00 2001
+From: Michael McAuliffe <michael.e.mcauliffe@gmail.com>
+Date: Fri, 5 Aug 2022 13:30:23 -0700
+Subject: [PATCH] Update installation of fsts headers
+
+---
+ src/include/Makefile.in | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/include/Makefile.in b/src/include/Makefile.in
+index 6e35e65..c68cb50 100644
+--- a/src/include/Makefile.in
++++ b/src/include/Makefile.in
+@@ -434,6 +434,11 @@ top_srcdir = @top_srcdir@
+ @HAVE_LINEAR_TRUE@fst/extensions/linear/linearscript.h fst/extensions/linear/loglinear-apply.h \
+ @HAVE_LINEAR_TRUE@fst/extensions/linear/trie.h
+ 
++@HAVE_FSTS_TRUE@linear_include_headers = fst/extensions/linear/linear-fst-data-builder.h \
++@HAVE_FSTS_TRUE@fst/extensions/linear/linear-fst-data.h fst/extensions/linear/linear-fst.h \
++@HAVE_FSTS_TRUE@fst/extensions/linear/linearscript.h fst/extensions/linear/loglinear-apply.h \
++@HAVE_FSTS_TRUE@fst/extensions/linear/trie.h
++
+ @HAVE_GRM_TRUE@mpdt_include_headers = fst/extensions/mpdt/compose.h \
+ @HAVE_GRM_TRUE@fst/extensions/mpdt/expand.h fst/extensions/mpdt/info.h \
+ @HAVE_GRM_TRUE@fst/extensions/mpdt/mpdt.h fst/extensions/mpdt/mpdtlib.h \
+@@ -449,6 +454,9 @@ top_srcdir = @top_srcdir@
+ @HAVE_NGRAM_TRUE@ngram_include_headers = fst/extensions/ngram/bitmap-index.h \
+ @HAVE_NGRAM_TRUE@fst/extensions/ngram/ngram-fst.h fst/extensions/ngram/nthbit.h
+ 
++@HAVE_FSTS_TRUE@ngram_include_headers = fst/extensions/ngram/bitmap-index.h \
++@HAVE_FSTS_TRUE@fst/extensions/ngram/ngram-fst.h fst/extensions/ngram/nthbit.h
++
+ @HAVE_GRM_TRUE@pdt_include_headers = fst/extensions/pdt/collection.h \
+ @HAVE_GRM_TRUE@fst/extensions/pdt/compose.h fst/extensions/pdt/expand.h \
+ @HAVE_GRM_TRUE@fst/extensions/pdt/getters.h fst/extensions/pdt/info.h \
+-- 
+2.37.1
+


### PR DESCRIPTION
Also reverts removal of cross-compilation logic for linux (in case aarch64 support gets added in the future)